### PR TITLE
fix: Documnet 发布时未设置应用别名

### DIFF
--- a/o2server/x_cms_assemble_control/src/main/java/com/x/cms/assemble/control/jaxrs/document/ActionPersistPublishContent.java
+++ b/o2server/x_cms_assemble_control/src/main/java/com/x/cms/assemble/control/jaxrs/document/ActionPersistPublishContent.java
@@ -127,6 +127,7 @@ public class ActionPersistPublishContent extends BaseAction {
 			wi.setDocumentType( categoryInfo.getDocumentType() );
 			wi.setAppId(categoryInfo.getAppId());
 			wi.setAppName(appInfo.getAppName());
+			wi.setAppAlias(appInfo.getAppAlias());
 			wi.setCategoryName(categoryInfo.getCategoryName());
 			wi.setCategoryId(categoryInfo.getId());
 			wi.setCategoryAlias(categoryInfo.getCategoryAlias());


### PR DESCRIPTION
修复 Documnet 发布时未设置应用别名的问题
这个地方没有设置应用别名默认会使用应用名称，在数据库按照应用别名查询的时候查询不出来