### PR TITLE
fix(sec): upgrade org.quartz-scheduler:quartz to 2.3.2

### DIFF
--- a/o2server/pom.xml
+++ b/o2server/pom.xml
@@ -875,7 +875,7 @@
 			<dependency>
 				<groupId>org.quartz-scheduler</groupId>
 				<artifactId>quartz</artifactId>
-				<version>2.3.1</version>
+				<version>2.3.2</version>
 			</dependency>
 			<dependency>
 				<groupId>org.imgscalr</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.quartz-scheduler:quartz 2.3.1
- [CVE-2019-13990](https://www.oscs1024.com/hd/CVE-2019-13990)


### What did I do？
Upgrade org.quartz-scheduler:quartz from 2.3.1 to 2.3.2 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS